### PR TITLE
Fix script error when received 302 response from server

### DIFF
--- a/http-vuln-exchange_v2.nse
+++ b/http-vuln-exchange_v2.nse
@@ -120,7 +120,7 @@ action = function(host, port)
   local answer = http.get(host, port, "/owa", options )
 
   if answer.status == 302 then
-    return "Error 302 " .. answer.location
+    return "Error 302 " .. table.concat(answer.location," -> ")
   elseif answer.status ~= 200 then
     return "Error " .. tostring(answer.status) .. " for /owa"
   end


### PR DESCRIPTION
Fixes a script execution error that occurred from trying to concatenate two incompatible types (string and table value)
`./http-vuln-exchange_v2.nse:123: attempt to concatenate a table value (field 'location')`